### PR TITLE
Added NX-OS

### DIFF
--- a/netmiko/cisco/cisco_nxos_ssh.py
+++ b/netmiko/cisco/cisco_nxos_ssh.py
@@ -6,6 +6,21 @@ from netmiko.cisco_base_connection import CiscoSSHConnection
 
 
 class CiscoNxosSSH(CiscoSSHConnection):
+    
+    @staticmethod
+    def autodetect(session):
+        """
+        """
+        matches = ["Cisco Nexus Operating System", "NX-OS"]
+        try:
+            response = session.send_command("show version | inc Cisco")
+            for m in matches:
+                if m in response:
+                    return 99
+        except:
+            return 0
+        return 0
+    
     def session_preparation(self):
         """
         Prepare the session after the connection has been established.

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -69,6 +69,6 @@ class SSHDetect(object):
             self.connection.disconnect()
             return None
 
-        best_match = sorted(self.potential_matches.items(), key=lambda t:t[0])
+        best_match = sorted(self.potential_matches.items(), key=lambda t:t[1], reverse=True)
         self.connection.disconnect()
         return best_match[0][0]

--- a/netmiko/ssh_autodetect.py
+++ b/netmiko/ssh_autodetect.py
@@ -9,7 +9,7 @@ from Netmiko.
 from netmiko.ssh_dispatcher import CLASS_MAPPER_BASE, ConnectHandler
 
 SSH_MAPPER_BASE = {}
-for k, v in CLASS_MAPPER_BASE.iteritems():
+for k, v in CLASS_MAPPER_BASE.items():
     if getattr(v, "autodetect", None):
         SSH_MAPPER_BASE[k] = v
 


### PR DESCRIPTION
Disclaimer: I use Python 3.6, so some of my changes may not be cross-compatible with 2.X (although I think they are).

I noticed you used `dict.iteritems()`, which isn't compatible in 3.x. Netmiko is cross-compatible with 3.x, so I changed it to `dict.items()`. I also added NX-OS checking, and updated what I believe was a sorting error in the best-match detection.